### PR TITLE
Fix CSS, Py3 compat, UTF-8 compat, add dedicated url_fix function (not used by html yet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # simple-proxy
 A simple Python proxy built with Tornado and BeautifulSoup
 
-Requires Python > 2.7.9 atm
+Requires Python > 2.7.9, Python > 3.
 
 `pip install -r requirements.txt`
 

--- a/proxy.py
+++ b/proxy.py
@@ -87,8 +87,9 @@ class MainHandler(web.RequestHandler):
         return rv
 
     def url_fix(self, url):
-        print url
-        if urisplit(url)[0]: # external / has scheme
+        if url.startswith('data:'): # data uri, not actually a link, leave it alone
+            rv = url
+        elif urisplit(url)[0]: # external / has scheme
             print 'external'
             rv = self.proxy + url
         elif urisplit(url)[1]: # protocol relatives prefixed with '//' / no scheme but has authority

--- a/proxy.py
+++ b/proxy.py
@@ -11,7 +11,6 @@
 # Usage (URL Format): [ip address]:[port]/[website address]
 # e.g. localhost:8000/www.example.com/file/path?query
 
-from urlparse import urlparse
 from uritools import uricompose, urijoin, urisplit, uriunsplit
 
 from tornado import ioloop, web, template
@@ -28,7 +27,7 @@ class MainHandler(web.RequestHandler):
         url = self.request.uri[1:] # strip the preceding forward slash
         if 'http' not in url:
             url = 'http://' + url
-        self.host = urlparse(url).scheme + '://' + urlparse(url).netloc
+        self.host = urisplit(url)[0] + '://' +  urisplit(url)[1]
         self.proxy = self.request.protocol + '://' + self.request.host
          # Initialize to empty string in case we need to return with it unset
         self.data = ""
@@ -75,7 +74,7 @@ class MainHandler(web.RequestHandler):
         and set the corrected attr by making all links absolute and run them
         through this proxy.
         '''
-        if not urlparse(asset[attr]).hostname: # relative url - make it absolute
+        if not urisplit(asset[attr])[1]: # relative url - make it absolute
             asset[attr] = '{0}{1}'.format(self.host, asset[attr])
         elif asset[attr][0:2] == '//': # protocol relatives prefixed with '//'
             asset[attr] = self.request.protocol + '://' + asset[attr][2:]
@@ -84,8 +83,8 @@ class MainHandler(web.RequestHandler):
         return
 
     def css_parse(self, line):
-        print "#### begin ####"
-        print 'line = ', line
+        print("#### begin ####")
+        print('line = ', line)
         beginning = 'url('
         end = ')'
         prefix = line.split(beginning)[0] + beginning
@@ -94,24 +93,24 @@ class MainHandler(web.RequestHandler):
 
         url_fixed = self.url_fix(url_to_fix)
         rv = prefix + '\'' + url_fixed + '\')' + suffix
-        print rv
-        print "##### end #####"
+        print(rv)
+        print("##### end #####")
         return rv
 
     def url_fix(self, url):
         if url.startswith('data:'): # data uri, not actually a link, leave it alone
             rv = url
         elif urisplit(url)[0]: # external / has scheme
-            print 'external'
+            print('external')
             rv = self.proxy + url
         elif urisplit(url)[1]: # protocol relatives prefixed with '//' / no scheme but has authority
-            print 'protocol relative'
+            print('protocol relative')
         elif not urisplit(url)[1] and urisplit(url)[2]: # relative or absolute / no authority but path
-            print 'relative or absolute'
+            print('relative or absolute')
             rv = self.proxy + '/' + urijoin(self.host, url)
         else:
             raise 'Unknown url protocol'
-        print rv
+        print(rv)
         return rv
 
     def get(self):

--- a/proxy.py
+++ b/proxy.py
@@ -30,7 +30,11 @@ class MainHandler(web.RequestHandler):
             url = 'http://' + url
         self.host = urlparse(url).scheme + '://' + urlparse(url).netloc
         self.proxy = self.request.protocol + '://' + self.request.host
-        r = requests.get(url)
+        try:
+            r = requests.get(url)
+        except requests.ConnectionError as e:
+            print("\nFailed to establish a connection with %s\n" % url)
+            raise e
 
         if "html" in r.headers['content-type']:
             soup = BeautifulSoup(r.text, 'lxml') # lxml - don't correct any messed up html

--- a/proxy.py
+++ b/proxy.py
@@ -52,7 +52,7 @@ class MainHandler(web.RequestHandler):
                 if 'url' in line:
                     line = self.css_parse(line)
                 rv = rv + line + '\n'
-            self.data = r.content
+            self.data = rv
 
         # critical to have resource files interpreted correctly
         self.set_header('content-type', r.headers['content-type'])
@@ -81,7 +81,7 @@ class MainHandler(web.RequestHandler):
         suffix = ')'.join(line.split(beginning)[1].split(end)[1:])
 
         url_fixed = self.url_fix(url_to_fix)
-        rv = prefix + '\'' + url_fixed + '\'' + suffix
+        rv = prefix + '\'' + url_fixed + '\')' + suffix
         print rv
         print "##### end #####"
         return rv

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4
 requests
 lxml
 uritools
+cssutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tornado
 beautifulsoup4
 requests
 lxml
+uritools


### PR DESCRIPTION
This also gives no errors when accessing terminallabs.com and github.com

TODO: 
- have html parser use url_fix (it's more robust)
- handle protocol relatives in url_fix
- think about possibly handling URI's in JS. maybe just won't. This is why google.com's main logo doesn't appear
- add tests?
